### PR TITLE
feat: Transaction Enhance

### DIFF
--- a/sqlike/database.go
+++ b/sqlike/database.go
@@ -77,6 +77,7 @@ func (db *Database) beginTrans(ctx context.Context, opt *sql.TxOptions) (*Transa
 	return &Transaction{
 		dbName:   db.name,
 		pk:       db.pk,
+		client:   db.client,
 		context:  ctx,
 		driver:   tx,
 		dialect:  db.dialect,
@@ -85,7 +86,7 @@ func (db *Database) beginTrans(ctx context.Context, opt *sql.TxOptions) (*Transa
 	}, nil
 }
 
-type txCallback func(ctx SessionContext) error
+type txCallback func(tx *Transaction) error
 
 // RunInTransaction :
 func (db *Database) RunInTransaction(cb txCallback, opts ...*options.TransactionOptions) error {

--- a/sqlike/find.go
+++ b/sqlike/find.go
@@ -76,7 +76,7 @@ func (tb *Table) Find(act actions.SelectStatement, opts ...*options.FindOptions)
 		tb.logger,
 		x,
 		opt,
-		options.NoLock,
+		opt.LockMode,
 	)
 	if csr.err != nil {
 		return nil, csr.err

--- a/sqlike/find.go
+++ b/sqlike/find.go
@@ -40,7 +40,7 @@ func (tb *Table) FindOne(act actions.SelectOneStatement, opts ...*options.FindOn
 		tb.logger,
 		&x.FindActions,
 		&opt.FindOptions,
-		options.NoLock,
+		opt.FindOptions.LockMode,
 	)
 	csr.close = true
 	if csr.err != nil {

--- a/sqlike/options/find.go
+++ b/sqlike/options/find.go
@@ -4,8 +4,8 @@ package options
 type FindOptions struct {
 	OmitFields []string
 	NoLimit    bool
-	// LockMode   LockMode
-	Debug bool
+	LockMode   LockMode
+	Debug      bool
 }
 
 // Find :
@@ -28,5 +28,11 @@ func (opt *FindOptions) SetDebug(debug bool) *FindOptions {
 // SetOmitFields :
 func (opt *FindOptions) SetOmitFields(fields ...string) *FindOptions {
 	opt.OmitFields = fields
+	return opt
+}
+
+// SetLockMode :
+func (opt *FindOptions) SetLockMode(lock LockMode) *FindOptions {
+	opt.LockMode = lock
 	return opt
 }

--- a/sqlike/options/find.go
+++ b/sqlike/options/find.go
@@ -10,7 +10,7 @@ type FindOptions struct {
 
 // Find :
 func Find() *FindOptions {
-	return &FindOptions{}
+	return &FindOptions{LockMode: NoLock}
 }
 
 // SetNoLimit :

--- a/sqlike/options/find_one.go
+++ b/sqlike/options/find_one.go
@@ -21,3 +21,9 @@ func (opt *FindOneOptions) SetOmitFields(fields ...string) *FindOneOptions {
 	opt.OmitFields = fields
 	return opt
 }
+
+// SetLockMode :
+func (opt *FindOneOptions) SetLockMode(lock LockMode) *FindOneOptions {
+	opt.LockMode = lock
+	return opt
+}

--- a/sqlike/session.go
+++ b/sqlike/session.go
@@ -1,222 +1,222 @@
 package sqlike
 
-import (
-	"database/sql"
+// import (
+// 	"database/sql"
 
-	"github.com/si3nloong/sqlike/sql/codec"
-	"github.com/si3nloong/sqlike/sqlike/actions"
-	"github.com/si3nloong/sqlike/sqlike/options"
-)
+// 	"github.com/si3nloong/sqlike/sql/codec"
+// 	"github.com/si3nloong/sqlike/sqlike/actions"
+// 	"github.com/si3nloong/sqlike/sqlike/options"
+// )
 
-// SessionContext :
-type SessionContext interface {
-	Table(name string) *Session
-}
+// // SessionContext :
+// type SessionContext interface {
+// 	Table(name string) *Session
+// }
 
-// Session :
-type Session struct {
-	dbName   string
-	table    string
-	pk       string
-	tx       *Transaction
-	registry *codec.Registry
-}
+// // Session :
+// type Session struct {
+// 	dbName   string
+// 	table    string
+// 	pk       string
+// 	tx       *Transaction
+// 	registry *codec.Registry
+// }
 
-// FindOne :
-func (sess *Session) FindOne(act actions.SelectOneStatement, lock options.LockMode, opts ...*options.FindOneOptions) SingleResult {
-	x := new(actions.FindOneActions)
-	if act != nil {
-		*x = *(act.(*actions.FindOneActions))
-	}
-	opt := new(options.FindOneOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	x.Limit(1)
-	csr := find(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.registry,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		&x.FindActions,
-		&opt.FindOptions,
-		lock,
-	)
-	csr.close = true
-	if csr.err != nil {
-		return csr
-	}
-	if !csr.Next() {
-		csr.err = sql.ErrNoRows
-	}
-	return csr
-}
+// // FindOne :
+// func (sess *Session) FindOne(act actions.SelectOneStatement, lock options.LockMode, opts ...*options.FindOneOptions) SingleResult {
+// 	x := new(actions.FindOneActions)
+// 	if act != nil {
+// 		*x = *(act.(*actions.FindOneActions))
+// 	}
+// 	opt := new(options.FindOneOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	x.Limit(1)
+// 	csr := find(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.registry,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		&x.FindActions,
+// 		&opt.FindOptions,
+// 		lock,
+// 	)
+// 	csr.close = true
+// 	if csr.err != nil {
+// 		return csr
+// 	}
+// 	if !csr.Next() {
+// 		csr.err = sql.ErrNoRows
+// 	}
+// 	return csr
+// }
 
-// Find :
-func (sess *Session) Find(act actions.SelectStatement, lock options.LockMode, opts ...*options.FindOptions) (*Result, error) {
-	x := new(actions.FindActions)
-	if act != nil {
-		*x = *(act.(*actions.FindActions))
-	}
-	opt := new(options.FindOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	csr := find(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.registry,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		x,
-		opt,
-		lock,
-	)
-	if csr.err != nil {
-		return nil, csr.err
-	}
-	return csr, nil
-}
+// // Find :
+// func (sess *Session) Find(act actions.SelectStatement, lock options.LockMode, opts ...*options.FindOptions) (*Result, error) {
+// 	x := new(actions.FindActions)
+// 	if act != nil {
+// 		*x = *(act.(*actions.FindActions))
+// 	}
+// 	opt := new(options.FindOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	csr := find(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.registry,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		x,
+// 		opt,
+// 		lock,
+// 	)
+// 	if csr.err != nil {
+// 		return nil, csr.err
+// 	}
+// 	return csr, nil
+// }
 
-// InsertOne :
-func (sess *Session) InsertOne(src interface{}, opts ...*options.InsertOneOptions) (sql.Result, error) {
-	opt := new(options.InsertOneOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	return insertOne(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.pk,
-		sess.registry,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		src,
-		opt,
-	)
-}
+// // InsertOne :
+// func (sess *Session) InsertOne(src interface{}, opts ...*options.InsertOneOptions) (sql.Result, error) {
+// 	opt := new(options.InsertOneOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	return insertOne(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.pk,
+// 		sess.registry,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		src,
+// 		opt,
+// 	)
+// }
 
-// Insert :
-func (sess *Session) Insert(src interface{}, opts ...*options.InsertOptions) (sql.Result, error) {
-	opt := new(options.InsertOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	return insertMany(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.pk,
-		sess.registry,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		src,
-		opt,
-	)
-}
+// // Insert :
+// func (sess *Session) Insert(src interface{}, opts ...*options.InsertOptions) (sql.Result, error) {
+// 	opt := new(options.InsertOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	return insertMany(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.pk,
+// 		sess.registry,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		src,
+// 		opt,
+// 	)
+// }
 
-// ModifyOne :
-func (sess *Session) ModifyOne(update interface{}, opts ...*options.ModifyOneOptions) error {
-	return modifyOne(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.pk,
-		sess.tx.dialect,
-		sess.tx.driver,
-		sess.tx.logger,
-		update,
-		opts,
-	)
-}
+// // ModifyOne :
+// func (sess *Session) ModifyOne(update interface{}, opts ...*options.ModifyOneOptions) error {
+// 	return modifyOne(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.pk,
+// 		sess.tx.dialect,
+// 		sess.tx.driver,
+// 		sess.tx.logger,
+// 		update,
+// 		opts,
+// 	)
+// }
 
-// UpdateOne :
-func (sess *Session) UpdateOne(act actions.UpdateOneStatement, opts ...*options.UpdateOneOptions) (int64, error) {
-	x := new(actions.UpdateOneActions)
-	if act != nil {
-		*x = *(act.(*actions.UpdateOneActions))
-	}
-	if x.Table == "" {
-		x.Table = sess.table
-	}
-	opt := new(options.UpdateOneOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	return update(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		&x.UpdateActions,
-		&opt.UpdateOptions,
-	)
-}
+// // UpdateOne :
+// func (sess *Session) UpdateOne(act actions.UpdateOneStatement, opts ...*options.UpdateOneOptions) (int64, error) {
+// 	x := new(actions.UpdateOneActions)
+// 	if act != nil {
+// 		*x = *(act.(*actions.UpdateOneActions))
+// 	}
+// 	if x.Table == "" {
+// 		x.Table = sess.table
+// 	}
+// 	opt := new(options.UpdateOneOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	return update(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		&x.UpdateActions,
+// 		&opt.UpdateOptions,
+// 	)
+// }
 
-// Update :
-func (sess *Session) Update(act actions.UpdateStatement, opts ...*options.UpdateOptions) (int64, error) {
-	x := new(actions.UpdateActions)
-	if act != nil {
-		*x = *(act.(*actions.UpdateActions))
-	}
-	opt := new(options.UpdateOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	return update(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		x,
-		opt,
-	)
-}
+// // Update :
+// func (sess *Session) Update(act actions.UpdateStatement, opts ...*options.UpdateOptions) (int64, error) {
+// 	x := new(actions.UpdateActions)
+// 	if act != nil {
+// 		*x = *(act.(*actions.UpdateActions))
+// 	}
+// 	opt := new(options.UpdateOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	return update(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		x,
+// 		opt,
+// 	)
+// }
 
-// DestroyOne :
-func (sess *Session) DestroyOne(delete interface{}) error {
-	return destroyOne(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.pk,
-		sess.tx.driver,
-		sess.tx.dialect,
-		sess.tx.logger,
-		delete,
-	)
-}
+// // DestroyOne :
+// func (sess *Session) DestroyOne(delete interface{}) error {
+// 	return destroyOne(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.pk,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		sess.tx.logger,
+// 		delete,
+// 	)
+// }
 
-// Delete :
-func (sess *Session) Delete(act actions.DeleteStatement, opts ...*options.DeleteOptions) (int64, error) {
-	x := new(actions.DeleteActions)
-	if act != nil {
-		*x = *(act.(*actions.DeleteActions))
-	}
-	opt := new(options.DeleteOptions)
-	if len(opts) > 0 && opts[0] != nil {
-		opt = opts[0]
-	}
-	return deleteMany(
-		sess.tx.context,
-		sess.dbName,
-		sess.table,
-		sess.tx.driver,
-		sess.tx.dialect,
-		getLogger(sess.tx.logger, opt.Debug),
-		x,
-		opt,
-	)
-}
+// // Delete :
+// func (sess *Session) Delete(act actions.DeleteStatement, opts ...*options.DeleteOptions) (int64, error) {
+// 	x := new(actions.DeleteActions)
+// 	if act != nil {
+// 		*x = *(act.(*actions.DeleteActions))
+// 	}
+// 	opt := new(options.DeleteOptions)
+// 	if len(opts) > 0 && opts[0] != nil {
+// 		opt = opts[0]
+// 	}
+// 	return deleteMany(
+// 		sess.tx.context,
+// 		sess.dbName,
+// 		sess.table,
+// 		sess.tx.driver,
+// 		sess.tx.dialect,
+// 		getLogger(sess.tx.logger, opt.Debug),
+// 		x,
+// 		opt,
+// 	)
+// }

--- a/sqlike/transaction.go
+++ b/sqlike/transaction.go
@@ -13,6 +13,7 @@ import (
 type Transaction struct {
 	dbName   string
 	pk       string
+	client   *Client
 	context  context.Context
 	driver   *sql.Tx
 	dialect  sqldialect.Dialect
@@ -21,14 +22,24 @@ type Transaction struct {
 }
 
 // Table :
-func (tx *Transaction) Table(name string) *Session {
-	return &Session{
+func (tx *Transaction) Table(name string) *Table {
+	return &Table{
 		dbName:   tx.dbName,
-		table:    name,
+		name:     name,
 		pk:       tx.pk,
-		tx:       tx,
+		client:   tx.client,
+		driver:   tx.driver,
+		dialect:  tx.dialect,
 		registry: tx.registry,
+		logger:   tx.logger,
 	}
+	// return &Session{
+	// 	dbName:   tx.dbName,
+	// 	table:    name,
+	// 	pk:       tx.pk,
+	// 	tx:       tx,
+	// 	registry: tx.registry,
+	// }
 }
 
 // RollbackTransaction :

--- a/sqlike/transaction_test.go
+++ b/sqlike/transaction_test.go
@@ -1,0 +1,203 @@
+package sqlike
+
+import (
+	"log"
+	"math/rand"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/si3nloong/sqlike/sql/expr"
+	sqlstmt "github.com/si3nloong/sqlike/sql/stmt"
+	"github.com/si3nloong/sqlike/sqlike/actions"
+	"github.com/si3nloong/sqlike/sqlike/options"
+)
+
+type debug struct{}
+
+// Debug :
+func (l debug) Debug(stmt *sqlstmt.Statement) {
+	log.Printf("%+v", stmt)
+	return
+}
+
+func getMySQLClient() *Database {
+	client := MustConnect("mysql",
+		options.Connect().
+			SetHost("127.0.0.1").
+			SetPort("3306").
+			SetUsername("root").
+			SetPassword("test"),
+	).
+		SetPrimaryKey("ID").
+		SetLogger(debug{})
+
+	os.Stdout.WriteString("Connected to MySQL!")
+
+	return client.Database("test")
+}
+
+func setupData(client *Database) *user {
+	client.Table("user").Migrate(new(user))
+	data := &user{ID: 1234, Name: "Oska"}
+	client.Table("user").InsertOne(data)
+	return data
+}
+
+func clearData(client *Database) {
+	client.Table("user").DestroyOne(&user{ID: 1234})
+}
+
+type user struct {
+	ID   int
+	Name string
+}
+
+func TestCreateCommit(t *testing.T) {
+	client := getMySQLClient()
+	client.Table("user").Migrate(new(user))
+
+	data := &user{ID: rand.Intn(10000), Name: "Oska"}
+	trx, _ := client.BeginTransaction()
+	trx.Table("user").InsertOne(data)
+
+	if err := trx.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err != nil {
+		t.Error("FindOne doesn't work well with InsertOne in transaction mode.")
+	}
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err == nil {
+		t.Error("InsertOne with transaciton mode shouldn't have result with normal FindOne.")
+	}
+
+	trx.CommitTransaction()
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err != nil {
+		t.Error("Result should exists after rollback transaction.")
+	}
+
+	// Remove tested data
+	client.Table("user").DestroyOne(data)
+}
+
+func TestCreateRollback(t *testing.T) {
+	client := getMySQLClient()
+	client.Table("user").Migrate(new(user))
+
+	data := &user{ID: 1234, Name: "Oska"}
+	trx, _ := client.BeginTransaction()
+	trx.Table("user").InsertOne(data)
+
+	if err := trx.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err != nil {
+		t.Error("FindOne doesn't work well with InsertOne in transaction mode.")
+	}
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err == nil {
+		t.Error("InsertOne with transaciton mode shouldn't have result with normal FindOne.")
+	}
+
+	trx.RollbackTransaction()
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err == nil {
+		t.Error("Result should exists after rollback transaction.")
+	}
+}
+
+func TestUpdateCommit(t *testing.T) {
+	client := getMySQLClient()
+	data := setupData(client)
+	defer clearData(client)
+
+	trx, _ := client.BeginTransaction()
+
+	data.Name = "Another Oska"
+	trx.Table("user").ModifyOne(data)
+
+	user1 := new(user)
+	trx.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(user1)
+	if user1.Name != "Another Oska" {
+		t.Error("Under same transaction should receive updated data.")
+	}
+
+	trx.CommitTransaction()
+
+	user2 := new(user)
+	client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(user2)
+	if user2.Name != "Another Oska" {
+		t.Error("Data should updated after transaction commit.")
+	}
+}
+
+func TestUpdateRollback(t *testing.T) {
+	client := getMySQLClient()
+	data := setupData(client)
+	defer clearData(client)
+
+	trx, _ := client.BeginTransaction()
+
+	data.Name = "Another Oska"
+	trx.Table("user").ModifyOne(data)
+
+	user1 := new(user)
+	trx.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(user1)
+	if user1.Name != "Another Oska" {
+		t.Error("Under same transaction should receive updated data.")
+	}
+
+	trx.RollbackTransaction()
+
+	user2 := new(user)
+	client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(user2)
+	if user2.Name != "Oska" {
+		t.Error("Data should recover to before after transaction rollback.")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	client := getMySQLClient()
+	data := setupData(client)
+	defer clearData(client)
+
+	trx, _ := client.BeginTransaction()
+
+	trx.Table("user").DestroyOne(data)
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err != nil {
+		t.Error("Data should exists with same transaction.")
+	}
+
+	trx.RollbackTransaction()
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err != nil {
+		t.Error("Data should exists if transaction have been rollback.")
+	}
+
+	trx2, _ := client.BeginTransaction()
+	trx2.Table("user").DestroyOne(data)
+	trx2.CommitTransaction()
+
+	if err := client.Table("user").FindOne(actions.FindOne().Where(expr.Equal("ID", data.ID))).Decode(&user{}); err == nil {
+		t.Error("Data should not exists if transaction have been rollback.")
+	}
+}
+
+func TestPaginateTrx(t *testing.T) {
+	client := getMySQLClient()
+
+	setupData(client)
+	defer clearData(client)
+
+	trx, _ := client.BeginTransaction()
+
+	trx.Table("user").InsertOne(&user{ID: 2234})
+	trx.Table("user").InsertOne(&user{ID: 3234})
+	trx.Table("user").InsertOne(&user{ID: 4234})
+	pg, _ := trx.Table("user").Paginate(actions.Paginate())
+
+	results := make([]*user, 0)
+	pg.All(&results)
+
+	if len(results) != 4 {
+		t.Error("Paginate doesn't work well in transaction mode.")
+	}
+
+	trx.RollbackTransaction()
+}

--- a/sqlike/transaction_test.go
+++ b/sqlike/transaction_test.go
@@ -201,3 +201,10 @@ func TestPaginateTrx(t *testing.T) {
 
 	trx.RollbackTransaction()
 }
+
+func TestLockMode(t *testing.T) {
+	opt := options.FindOne().SetLockMode(options.LockForRead)
+	if opt.LockMode != options.LockForRead {
+		t.Error("Lock mode doens't update in FindOneOptions.")
+	}
+}


### PR DESCRIPTION
Changes
* Return `*Transaction` instead of `*SessionContext` when start a transaction
* `*Transaction.Table()` return `*Table` instead of `*Session` able to use table crud method directly.
* Reliability testing file for transactions call `all actions`

Pending
* Examples

[LAST EDIT] 07/12/2019 21:46